### PR TITLE
Explicitly set MIDDLEWARE_CLASSES for tests

### DIFF
--- a/tests/tests/settings.py
+++ b/tests/tests/settings.py
@@ -9,6 +9,13 @@ INSTALLED_APPS = (
     'tests',
 )
 
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+)
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
Django 1.7 pared down the default MIDDLEWARE_CLASSES, so we have to explicitly include auth and sessions.
